### PR TITLE
Add Home page and nested tabs support

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,21 @@
-import React from 'react';
-import { DndContext } from '@dnd-kit/core';
+import React, { useEffect, useState } from 'react';
 import FormBuilder from './components/FormBuilder/FormBuilder';
+import Home from './pages/Home';
 import { FormProvider } from './context/FormContext';
 
 function App() {
+  const [route, setRoute] = useState(window.location.hash.replace('#', '') || 'home');
+
+  useEffect(() => {
+    const handler = () => setRoute(window.location.hash.replace('#', '') || 'home');
+    window.addEventListener('hashchange', handler);
+    return () => window.removeEventListener('hashchange', handler);
+  }, []);
+
   return (
     <FormProvider>
       <div className="app-container h-screen flex flex-col">
-        <FormBuilder />
+        {route === 'builder' ? <FormBuilder /> : <Home />}
       </div>
     </FormProvider>
   );

--- a/src/components/FormBuilder/FormBuilderCanvas.jsx
+++ b/src/components/FormBuilder/FormBuilderCanvas.jsx
@@ -10,27 +10,24 @@ const FormBuilderCanvas = () => {
   const { components } = formState;
 
   // Recursive renderer for nested components
-  const renderComponent = (component, index, parentId = null) => {
+  const renderComponent = (component, index) => {
+    let content = null;
     if (component.type === 'tabs') {
-      return <TabsContainer key={component.id} component={component} />;
-    }
-    if (component.type === 'columns') {
-      return <ColumnsContainer key={component.id} component={component} />;
-    }
-    if (component.components) {
-      return (
-        <PanelContainer key={component.id} component={component}>
-          {component.components.map((child, idx) => renderComponent(child, idx, component.id))}
+      content = <TabsContainer component={component} renderComponent={renderComponent} />;
+    } else if (component.type === 'columns') {
+      content = <ColumnsContainer component={component} renderComponent={renderComponent} />;
+    } else if (component.components) {
+      content = (
+        <PanelContainer component={component}>
+          {component.components.map((child, idx) => renderComponent(child, idx))}
         </PanelContainer>
       );
     }
-    // Default: render as sortable
+
     return (
-      <SortableFormComponent
-        key={component.id}
-        component={component}
-        index={index}
-      />
+      <SortableFormComponent key={component.id} component={component} index={index}>
+        {content}
+      </SortableFormComponent>
     );
   };
 
@@ -51,7 +48,7 @@ const FormBuilderCanvas = () => {
 };
 
 // Tabs container
-const TabsContainer = ({ component }) => {
+const TabsContainer = ({ component, renderComponent }) => {
   const [activeTab, setActiveTab] = useState(0);
   const tabs = component.tabs || [];
   return (
@@ -77,6 +74,7 @@ const TabsContainer = ({ component }) => {
           componentId={component.id}
           tabIdx={activeTab}
           tab={tabs[activeTab]}
+          renderComponent={renderComponent}
         />
       </div>
     </div>
@@ -84,7 +82,7 @@ const TabsContainer = ({ component }) => {
 };
 
 // Columns container
-const ColumnsContainer = ({ component }) => {
+const ColumnsContainer = ({ component, renderComponent }) => {
   const columns = component.columns || [];
   return (
     <div className="mb-4">
@@ -96,6 +94,7 @@ const ColumnsContainer = ({ component }) => {
               componentId={component.id}
               columnIdx={idx}
               column={column}
+              renderComponent={renderComponent}
             />
           </div>
         ))}
@@ -121,7 +120,7 @@ const PanelContainer = ({ component, children }) => {
 };
 
 // Droppable area for a tab
-const TabDroppable = ({ componentId, tabIdx, tab }) => {
+const TabDroppable = ({ componentId, tabIdx, tab, renderComponent }) => {
   const { setNodeRef } = useDroppable({
     id: `tab-${componentId}-${tabIdx}`,
     data: {
@@ -137,14 +136,11 @@ const TabDroppable = ({ componentId, tabIdx, tab }) => {
       className="min-h-[60px] border-2 border-dashed border-gray-200 rounded-md p-2 bg-gray-50"
     >
       {(tab?.components || []).length > 0 ? (
-        tab.components.map((child, i) =>
-          // Recursively render nested components
+        tab.components.map((child, i) => (
           <React.Fragment key={child.id || i}>
-            {/* Use renderComponent if you want full nesting */}
-            {/* renderComponent(child, i, `tab-${componentId}-${tabIdx}`) */}
-            <SortableFormComponent component={child} index={i} />
+            {renderComponent(child, i)}
           </React.Fragment>
-        )
+        ))
       ) : (
         <div className="text-gray-400 text-sm text-center py-4">Drop fields here</div>
       )}
@@ -153,7 +149,7 @@ const TabDroppable = ({ componentId, tabIdx, tab }) => {
 };
 
 // Droppable area for a column
-const ColumnDroppable = ({ componentId, columnIdx, column }) => {
+const ColumnDroppable = ({ componentId, columnIdx, column, renderComponent }) => {
   const { setNodeRef } = useDroppable({
     id: `column-${componentId}-${columnIdx}`,
     data: {
@@ -169,13 +165,11 @@ const ColumnDroppable = ({ componentId, columnIdx, column }) => {
       className="min-h-[60px] border-2 border-dashed border-gray-200 rounded-md p-2 bg-gray-50"
     >
       {(column?.components || []).length > 0 ? (
-        column.components.map((child, i) =>
-          // Recursively render nested components
+        column.components.map((child, i) => (
           <React.Fragment key={child.id || i}>
-            {/* Use renderComponent if you want full nesting */}
-            <SortableFormComponent component={child} index={i} />
+            {renderComponent(child, i)}
           </React.Fragment>
-        )
+        ))
       ) : (
         <div className="text-gray-400 text-sm text-center py-4">Drop fields here</div>
       )}

--- a/src/components/FormBuilder/FormBuilderHeader.jsx
+++ b/src/components/FormBuilder/FormBuilderHeader.jsx
@@ -5,11 +5,12 @@ import FormPreview from '../FormPreview/FormPreview';
 
 
 const FormBuilderHeader = () => {
-  const { 
-    formState, 
-    updateFormMetadata, 
-    exportFormSchema, 
+  const {
+    formState,
+    updateFormMetadata,
+    exportFormSchema,
     importFormSchema,
+    saveForm,
     undo,
     redo,
     canUndo,
@@ -97,6 +98,10 @@ const FormBuilderHeader = () => {
     } catch {
       toast.error('Failed to copy JSON');
     }
+  };
+
+  const handleSave = () => {
+    saveForm();
   };
 
   return (
@@ -197,7 +202,8 @@ const FormBuilderHeader = () => {
           </svg>
         </button>
         
-        <button 
+        <button
+          onClick={handleSave}
           className="ml-2 px-4 py-2 bg-primary text-white rounded-md hover:bg-primary-dark transition-colors text-sm font-medium"
         >
           Save Form

--- a/src/components/FormComponents/SortableFormComponent.jsx
+++ b/src/components/FormComponents/SortableFormComponent.jsx
@@ -4,7 +4,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { useForm } from '../../context/FormContext';
 import ComponentPreview from './ComponentPreview';
 
-const SortableFormComponent = ({ component, index }) => {
+const SortableFormComponent = ({ component, index, children }) => {
   const { selectedComponent, setSelectedComponent } = useForm();
   const isSelected = selectedComponent && selectedComponent.id === component.id;
   
@@ -50,7 +50,7 @@ const SortableFormComponent = ({ component, index }) => {
       {...listeners}
     >
       <div className="flex items-start group">
-        <div 
+        <div
           className="cursor-grab p-2 text-gray-400 hover:text-gray-600 drag-handle opacity-0 group-hover:opacity-100 transition-opacity"
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -71,6 +71,7 @@ const SortableFormComponent = ({ component, index }) => {
           )}
         </div>
       </div>
+      {children}
     </div>
   );
 };

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import { useForm } from '../context/FormContext';
+
+const Home = () => {
+  const { listForms, loadForm, deleteForm, newForm } = useForm();
+  const [forms, setForms] = useState([]);
+
+  const refresh = () => {
+    setForms(listForms());
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const handleEdit = (id) => {
+    loadForm(id);
+    window.location.hash = 'builder';
+  };
+
+  const handleDelete = (id) => {
+    if (window.confirm('Delete this form?')) {
+      deleteForm(id);
+      refresh();
+    }
+  };
+
+  const handleNew = () => {
+    newForm();
+    window.location.hash = 'builder';
+  };
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Saved Forms</h1>
+      {forms.length === 0 ? (
+        <p className="text-gray-500">No forms saved.</p>
+      ) : (
+        <ul className="space-y-2">
+          {forms.map((form) => (
+            <li key={form.id} className="border p-3 rounded flex justify-between items-center">
+              <span>{form.title}</span>
+              <div className="space-x-2">
+                <button className="text-primary text-sm" onClick={() => handleEdit(form.id)}>Edit</button>
+                <button className="text-error text-sm" onClick={() => handleDelete(form.id)}>Delete</button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+      <button onClick={handleNew} className="px-4 py-2 bg-primary text-white rounded">
+        New Form
+      </button>
+    </div>
+  );
+};
+
+export default Home;


### PR DESCRIPTION
## Summary
- implement hash-based routing and new Home page
- support saving/loading forms via localStorage in FormContext
- add Save Form action
- allow recursive rendering of nested tabs/columns

## Testing
- `npm run lint` *(fails: cannot find eslint-plugin-react)*