### PR TITLE
Fix nested drop IDs and hide horizontal scroll

### DIFF
--- a/src/components/FormBuilder/FormBuilder.jsx
+++ b/src/components/FormBuilder/FormBuilder.jsx
@@ -54,10 +54,8 @@ const FormBuilder = () => {
     const components = formState.components;
 
     // Handle drop into a tab
-    if (overId && typeof overId === 'string' && overId.startsWith('tab-')) {
-      // overId format: tab-<tabsComponentId>-<tabIdx>
-      const [, tabsComponentId, tabIdxStr] = overId.split('-');
-      const tabIdx = parseInt(tabIdxStr, 10);
+    if (over?.data?.current?.type === 'tab') {
+      const { componentId: tabsComponentId, tabIdx } = over.data.current;
 
       if (active.data?.current?.isNew) {
         const { type, label, suggestedKey } = active.data.current;
@@ -75,10 +73,8 @@ const FormBuilder = () => {
     }
 
     // Handle drop into a column
-    if (overId && typeof overId === 'string' && overId.startsWith('column-')) {
-      // overId format: column-<columnsComponentId>-<columnIdx>
-      const [, columnsComponentId, columnIdxStr] = overId.split('-');
-      const columnIdx = parseInt(columnIdxStr, 10);
+    if (over?.data?.current?.type === 'column') {
+      const { componentId: columnsComponentId, columnIdx } = over.data.current;
 
       if (active.data?.current?.isNew) {
         const { type, label, suggestedKey } = active.data.current;

--- a/src/components/FormBuilder/FormBuilderProperties.jsx
+++ b/src/components/FormBuilder/FormBuilderProperties.jsx
@@ -58,7 +58,7 @@ const FormBuilderProperties = () => {
   // If no component is selected, show empty state
   if (!selectedComponent) {
     return (
-      <div className="w-80 border-l border-gray-200 bg-gray-50 overflow-y-auto h-full hidden md:block">
+      <div className="w-80 border-l border-gray-200 bg-gray-50 overflow-y-auto overflow-x-hidden h-full hidden md:block">
         <div className="p-6 h-full flex items-center justify-center text-center">
           <div className="text-gray-500">
             <svg xmlns="http://www.w3.org/2000/svg" className="h-12 w-12 mx-auto mb-4 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -74,7 +74,7 @@ const FormBuilderProperties = () => {
   }
 
   return (
-    <div className="w-80 border-l border-gray-200 bg-white overflow-y-auto h-full hidden md:block">
+    <div className="w-80 border-l border-gray-200 bg-white overflow-y-auto overflow-x-hidden h-full hidden md:block">
       <div className="sticky top-0 bg-white border-b border-gray-200 p-4 z-10">
         <div className="flex items-center justify-between mb-2">
           <h3 className="font-semibold text-gray-800 flex items-center">
@@ -95,7 +95,7 @@ const FormBuilderProperties = () => {
           </button>
         </div>
         
-        <div className="flex space-x-1 bg-gray-100 p-1 rounded-md">
+        <div className="flex space-x-1 bg-gray-100 p-1 rounded-md overflow-x-auto">
           {PROPERTY_TABS.map((tab) => (
             <button
               key={tab.id}


### PR DESCRIPTION
## Summary
- fix drag/drop ID parsing by reading data from event instead of parsing strings
- hide horizontal scrollbar in builder property panel
- allow property tab list to scroll so all tabs remain accessible

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*